### PR TITLE
Bug in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ EVAL_IMAGE_NAME := text-to-sql-eval
 
 BUILDKIT_IMAGE := tscholak/text-to-sql-buildkit:buildx-stable-1
 BUILDKIT_BUILDER ?= buildx-local
+BASE_DIR := $(shell pwd)
 
 .PHONY: init-buildkit
 init-buildkit:
@@ -110,10 +111,10 @@ train: pull-train-image
 		-it \
 		--rm \
 		--user 13011:13011 \
-		--mount type=bind,source=$(PWD)/train,target=/train \
-		--mount type=bind,source=$(PWD)/transformers_cache,target=/transformers_cache \
-		--mount type=bind,source=$(PWD)/configs,target=/app/configs \
-		--mount type=bind,source=$(PWD)/wandb,target=/app/wandb \
+		--mount type=bind,source=$(BASE_DIR)/train,target=/train \
+		--mount type=bind,source=$(BASE_DIR)/transformers_cache,target=/transformers_cache \
+		--mount type=bind,source=$(BASE_DIR)/configs,target=/app/configs \
+		--mount type=bind,source=$(BASE_DIR)/wandb,target=/app/wandb \
 		tscholak/$(TRAIN_IMAGE_NAME):$(GIT_HEAD_REF) \
 		/bin/bash -c "python seq2seq/run_seq2seq.py configs/train.json"
 
@@ -126,10 +127,10 @@ train_cosql: pull-train-image
 		-it \
 		--rm \
 		--user 13011:13011 \
-		--mount type=bind,source=$(PWD)/train,target=/train \
-		--mount type=bind,source=$(PWD)/transformers_cache,target=/transformers_cache \
-		--mount type=bind,source=$(PWD)/configs,target=/app/configs \
-		--mount type=bind,source=$(PWD)/wandb,target=/app/wandb \
+		--mount type=bind,source=$(BASE_DIR)/train,target=/train \
+		--mount type=bind,source=$(BASE_DIR)/transformers_cache,target=/transformers_cache \
+		--mount type=bind,source=$(BASE_DIR)/configs,target=/app/configs \
+		--mount type=bind,source=$(BASE_DIR)/wandb,target=/app/wandb \
 		tscholak/$(TRAIN_IMAGE_NAME):$(GIT_HEAD_REF) \
 		/bin/bash -c "python seq2seq/run_seq2seq.py configs/train_cosql.json"
 
@@ -142,10 +143,10 @@ eval: pull-eval-image
 		-it \
 		--rm \
 		--user 13011:13011 \
-		--mount type=bind,source=$(PWD)/eval,target=/eval \
-		--mount type=bind,source=$(PWD)/transformers_cache,target=/transformers_cache \
-		--mount type=bind,source=$(PWD)/configs,target=/app/configs \
-		--mount type=bind,source=$(PWD)/wandb,target=/app/wandb \
+		--mount type=bind,source=$(BASE_DIR)/eval,target=/eval \
+		--mount type=bind,source=$(BASE_DIR)/transformers_cache,target=/transformers_cache \
+		--mount type=bind,source=$(BASE_DIR)/configs,target=/app/configs \
+		--mount type=bind,source=$(BASE_DIR)/wandb,target=/app/wandb \
 		tscholak/$(EVAL_IMAGE_NAME):$(GIT_HEAD_REF) \
 		/bin/bash -c "python seq2seq/run_seq2seq.py configs/eval.json"
 
@@ -158,10 +159,10 @@ eval_cosql: pull-eval-image
 		-it \
 		--rm \
 		--user 13011:13011 \
-		--mount type=bind,source=$(PWD)/eval,target=/eval \
-		--mount type=bind,source=$(PWD)/transformers_cache,target=/transformers_cache \
-		--mount type=bind,source=$(PWD)/configs,target=/app/configs \
-		--mount type=bind,source=$(PWD)/wandb,target=/app/wandb \
+		--mount type=bind,source=$(BASE_DIR)/eval,target=/eval \
+		--mount type=bind,source=$(BASE_DIR)/transformers_cache,target=/transformers_cache \
+		--mount type=bind,source=$(BASE_DIR)/configs,target=/app/configs \
+		--mount type=bind,source=$(BASE_DIR)/wandb,target=/app/wandb \
 		tscholak/$(EVAL_IMAGE_NAME):$(GIT_HEAD_REF) \
 		/bin/bash -c "python seq2seq/run_seq2seq.py configs/eval_cosql.json"
 
@@ -174,8 +175,8 @@ serve: pull-eval-image
 		--rm \
 		--user 13011:13011 \
 		-p 8000:8000 \
-		--mount type=bind,source=$(PWD)/database,target=/database \
-		--mount type=bind,source=$(PWD)/transformers_cache,target=/transformers_cache \
-		--mount type=bind,source=$(PWD)/configs,target=/app/configs \
+		--mount type=bind,source=$(BASE_DIR)/database,target=/database \
+		--mount type=bind,source=$(BASE_DIR)/transformers_cache,target=/transformers_cache \
+		--mount type=bind,source=$(BASE_DIR)/configs,target=/app/configs \
 		tscholak/$(EVAL_IMAGE_NAME):$(GIT_HEAD_REF) \
 		/bin/bash -c "python seq2seq/serve_seq2seq.py configs/serve.json"


### PR DESCRIPTION
Command **"$(PWD)"** was not able to fetch the absolute path. So, I created a variable **"BASE_DIR := $(shell pwd)"** and used this where ever base directory path was required. On ubuntu system I was facing below error so made this change. I think this error might be there for other ubuntu users as well so creating a PR.  Thank you

`docker pull tscholak/text-to-sql-eval:dd6dc5851cc76c9012b45488b901574c8b7f4862
dd6dc5851cc76c9012b45488b901574c8b7f4862: Pulling from tscholak/text-to-sql-eval
Digest: sha256:28b9b2686d4c3a82081e2a5424bfc6dcefeb3c84f55079502850f2fafecf4451
Status: Image is up to date for tscholak/text-to-sql-eval:dd6dc5851cc76c9012b45488b901574c8b7f4862
docker.io/tscholak/text-to-sql-eval:dd6dc5851cc76c9012b45488b901574c8b7f4862
mkdir -p -m 777 database
mkdir -p -m 777 transformers_cache
docker run \
        -it \
        --rm \
        --user 13011:13011 \
        -p 8000:8000 \
        --mount type=bind,source=/database,target=/database \
        --mount type=bind,source=/transformers_cache,target=/transformers_cache \
        --mount type=bind,source=/configs,target=/configs \
        tscholak/text-to-sql-eval:dd6dc5851cc76c9012b45488b901574c8b7f4862 \
        /bin/bash -c "python seq2seq/serve_seq2seq.py configs/serve.json"
docker: Error response from daemon: invalid mount config for type "bind": bind source path does not exist: /database.
See 'docker run --help'.`