### PR TITLE
support for SpiderDK

### DIFF
--- a/configs/eval_spider_dk.json
+++ b/configs/eval_spider_dk.json
@@ -1,5 +1,5 @@
 {
-    "run_name": "t5+picard-spider-syn",
+    "run_name": "t5+picard-spider-dk",
     "model_name_or_path": "tscholak/cxmefzzi",
     "dataset": "spider_dk",
     "source_prefix": "",

--- a/seq2seq/datasets/spider_dk/spider_dk.py
+++ b/seq2seq/datasets/spider_dk/spider_dk.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Spider-Syn: Spider Syn Dataset for evaluating Text-SQL models"""
+"""Spider-DK: Exploring Underexplored Limitations of Cross-Domain Text-to-SQL Generalization"""
 
 import json
 from turtle import down
@@ -23,31 +23,33 @@ from typing import List, Generator, Any, Dict, Tuple
 logger = datasets.logging.get_logger(__name__)
 
 _CITATION = """
-@article{gan2021towards,
-  title={Towards robustness of text-to-SQL models against synonym substitution},
-  author={Gan, Yujian and Chen, Xinyun and Huang, Qiuping and Purver, Matthew and Woodward, John R and Xie, Jinxia and Huang, Pengsheng},
-  journal={arXiv preprint arXiv:2106.01065},
-  year={2021}
+@misc{gan2021exploring,
+      title={Exploring Underexplored Limitations of Cross-Domain Text-to-SQL Generalization}, 
+      author={Yujian Gan and Xinyun Chen and Matthew Purver},
+      year={2021},
+      eprint={2109.05157},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL}
 }
 """
 
 _DESCRIPTION = """\
-    Spider-Syn: synthesized data for original spider dataset.
+    Spider-DK new domain-data data for original spider dataset.
 """
 
-_HOMEPAGE = "https://zenodo.org/record/5205322#.Yh-B1uhByUl"
+_HOMEPAGE = "https://github.com/ygan/Spider-DK"
 
 _LICENCE = "CC BY-SA 4.0"
 
-_URL = "https://github.com/ygan/Spider-Syn/blob/main/Spider-Syn/dev.json"
+_URL = "https://github.com/ygan/Spider-DK/blob/main/Spider-DK.json"
 
-class SpiderSyn(datasets.GeneratorBasedBuilder):
+class SpiderDK(datasets.GeneratorBasedBuilder):
     VERSION = datasets.Version("1.0.0")
 
     BUILDER_CONFIGS = [datasets.BuilderConfig(
-        name = "spider-syn",
+        name = "spider-dk",
         version = VERSION,
-        description="Spider-Syn: Original spider dev data modified to test robustness of text-to-SQL models against synonym substitution."
+        description="Spider-DK: Original spider dev data modified for Exploring Underexplored Limitations of Cross-Domain Text-to-SQL Generalization"
     )]
 
 
@@ -98,8 +100,8 @@ class SpiderSyn(datasets.GeneratorBasedBuilder):
             datasets.SplitGenerator(
                 name = datasets.Split.VALIDATION,
                 gen_kwargs={
-                    "data_filepaths":[downloaded_filepath + "/spider-syn/spider-syn.json"],
-                    "db_path": downloaded_filepath + "/spider-syn/database",
+                    "data_filepaths":[downloaded_filepath + "/spider-dk/spider-DK.json"],
+                    "db_path": downloaded_filepath + "/spider-dk/database",
                 },
             ),
         ]
@@ -109,14 +111,10 @@ class SpiderSyn(datasets.GeneratorBasedBuilder):
     ) -> Generator[Tuple[int, Dict[str, Any]], None, None]:
     
         for data_filepath in data_filepaths:
-            if(data_filepath.find('train_spider.json')>=0):
-                question_field = "question"
-            else:
-                question_field = "SpiderSynQuestion"
             logger.info("generating examples form = %s", data_filepath)
             with open(data_filepath, encoding='utf-8') as f:
-                spider_syn = json.load(f)
-                for idx, sample in enumerate(spider_syn):
+                spider_dk = json.load(f)
+                for idx, sample in enumerate(spider_dk):
                     db_id = sample['db_id']
                     if db_id not in self.schema_cache:
                         self.schema_cache[db_id] = dump_db_json_schema(
@@ -125,7 +123,7 @@ class SpiderSyn(datasets.GeneratorBasedBuilder):
                     schema = self.schema_cache[db_id]
                     yield idx, {
                         "query": sample['query'],
-                        "question": sample[question_field],
+                        "question": sample['question'],
                         "db_id": db_id,
                         "db_path": db_path,
                         "db_table_names": schema["table_names_original"],

--- a/seq2seq/run_seq2seq.py
+++ b/seq2seq/run_seq2seq.py
@@ -195,7 +195,7 @@ def main() -> None:
             "target_with_db_id": data_training_args.target_with_db_id,
         }
         #using spidertrainer as it is.
-        if data_args.dataset in ["spider", "spider_realistic", "spider_syn"]:
+        if data_args.dataset in ["spider", "spider_realistic", "spider_syn", "spider_dk"]:
             trainer = SpiderTrainer(**trainer_kwargs)
         elif data_args.dataset in ["cosql", "cosql+spider"]:
             trainer = CoSQLTrainer(**trainer_kwargs)

--- a/seq2seq/utils/dataset.py
+++ b/seq2seq/utils/dataset.py
@@ -127,14 +127,15 @@ class DataTrainingArguments:
 @dataclass
 class DataArguments:
     dataset: str = field(
-        metadata={"help": "The dataset to be used. Choose between ``spider``, ``cosql``, or ``cosql+spider``, or ``spider_realistic``."},
+        metadata={"help": "The dataset to be used. Choose between ``spider``, ``cosql``, or ``cosql+spider``, or ``spider_realistic``, or ``spider_syn``, or ``spider_dk``."},
     )
     dataset_paths: Dict[str, str] = field(
         default_factory=lambda: {
             "spider": "./seq2seq/datasets/spider",
             "cosql": "./seq2seq/datasets/cosql",
             "spider_realistic": "./seq2seq/datasets/spider_realistic",
-            "spider_syn": "./seq2seq/datasets/spider_syn"
+            "spider_syn": "./seq2seq/datasets/spider_syn",
+            "spider_dk": "./seq2seq/datasets/spider_dk"
 
         },
         metadata={"help": "Paths of the dataset modules."},
@@ -149,7 +150,8 @@ class DataArguments:
             "spider": "./seq2seq/metrics/spider",
             "spider_realistic" : "./seq2seq/metrics/spider",
             "cosql": "./seq2seq/metrics/cosql",
-            "spider_syn":"./seq2seq/metrics/spider"
+            "spider_syn":"./seq2seq/metrics/spider",
+            "spider_dk":"./seq2seq/metrics/spider"
         },
         metadata={"help": "Paths of the metric modules."},
     )

--- a/seq2seq/utils/dataset_loader.py
+++ b/seq2seq/utils/dataset_loader.py
@@ -91,6 +91,13 @@ def load_dataset(
         path=data_args.metric_paths["spider_syn"], config_name=data_args.metric_config, test_suite_db_dir=data_args.test_suite_db_dir
     )
 
+    _spider_dk_dataset_dict : Callable[[], DatasetDict] = lambda: datasets.load.load_dataset(
+        path=data_args.dataset_paths['spider_dk'], cache_dir=model_args.cache_dir
+    )
+    _spider_dk_metric: Callable[[], Metric] = lambda: datasets.load.load_metric(
+        path=data_args.metric_paths["spider_dk"], config_name=data_args.metric_config, test_suite_db_dir=data_args.test_suite_db_dir
+    )
+
     _prepare_splits_kwargs = {
         "data_args": data_args,
         "training_args": training_args,
@@ -117,6 +124,14 @@ def load_dataset(
         metric = _spider_realistic_metric()
         dataset_splits = prepare_splits(
             dataset_dict= _spider_realistic_dataset_dict(),
+            add_serialized_schema=_spider_add_serialized_schema,
+            pre_process_function=_spider_pre_process_function,
+            **_prepare_splits_kwargs,
+        )
+    elif data_args.dataset == "spider_dk":
+        metric = _spider_dk_metric()
+        dataset_splits = prepare_splits(
+            dataset_dict= _spider_dk_dataset_dict(),
             add_serialized_schema=_spider_add_serialized_schema,
             pre_process_function=_spider_pre_process_function,
             **_prepare_splits_kwargs,


### PR DESCRIPTION
Hi @tscholak,

Forgot to mention this but, I have added support for Spider-DK. The solution assumes that the database directory contains all the necessary files to evaluate spider-DK (like downloading the new_* DB schemas and merging them with the old ones).
The numbers I obtained are 62.43 for EX accuracy and 49.72 for EM accuracy.
Please let me know if this sounds good to you or you need any more modifications to be made from my side.

Thank you,
Saurabh